### PR TITLE
Fix freeze highchart.js version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: exploratorium
 Title: Exploring Investements in Health Promotion and Disease Prevention
     in Switzerland
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
     person("Margot", "Brard", , "margot@thinkr.fr", role = c("aut", "cre")),
     person("Antoine", "Languillaume", , "antoine@thinkr.fr", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# exploratorium 1.0.1
+
+- Freeze highchart.js version number to avoid breaking changes in the library to
+  affect the app.
+
 # exploratorium 1.0.0
 
 - Data is now extracted directly from the Promotion Digitale Database before being

--- a/R/app_ui.R
+++ b/R/app_ui.R
@@ -65,13 +65,13 @@ golem_add_external_resources <- function() {
       ext = "png"
     ),
     tags$script(
-      src = "https://code.highcharts.com/highcharts.js"
+      src = "https://code.highcharts.com/12.0.0/highcharts.js"
     ),
     tags$script(
-      src = "https://code.highcharts.com/modules/accessibility.js"
+      src = "https://code.highcharts.com/12.0.0/modules/accessibility.js"
     ),
     tags$script(
-      src = "https://code.highcharts.com/modules/exporting.js"
+      src = "https://code.highcharts.com/12.0.0/modules/exporting.js"
     ),
     bundle_resources(
       path = app_sys("app/www"),


### PR DESCRIPTION
Freeze highchart.js version number to avoid breaking changes in the library to
  affect the app.
